### PR TITLE
[stable/zetcd] Fix zetcd template when etcd-operator disabled

### DIFF
--- a/stable/zetcd/Chart.yaml
+++ b/stable/zetcd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: CoreOS zetcd Helm chart for Kubernetes
 name: zetcd
-version: 0.1.5
+version: 0.1.6
 appVersion: 0.0.3
 home: https://github.com/coreos/zetcd
 sources:

--- a/stable/zetcd/templates/deployment.yaml
+++ b/stable/zetcd/templates/deployment.yaml
@@ -27,7 +27,8 @@ spec:
             - "-endpoints"
             - "{{ index .Values "etcd-operator" "cluster" "name" }}-client:2379"
 {{- else }}
-            - "-endpoints {{ .Values.etcd.endpoints }}"
+            - "-endpoints" 
+            - "{{ .Values.etcd.endpoints }}"
 {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}


### PR DESCRIPTION
Chart template was invalid if `.Values.etcd.operatorEnabled = false`